### PR TITLE
New wrappers to libBMC and libasdk

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -5,6 +5,13 @@ Summary of user-visible changes for version x.y.z (yyyy/mm/dd):
 
  ** New classes Client and DataClient.
 
+ ** New sub-package named wrappers to provide a wrapper of
+    manufacturers SDK and whatnot.
+
+ ** New microscope.wrappers modules libBMC and libasdk wrapping the C
+    libraries with the same, the SDK's for deformable mirrors from
+    Boston Micromachines Corporation (BMC) and Alpao.
+
  ** New dependency on six.
 
  ** Removed dependency on PyME.

--- a/microscope/wrappers/libBMC.py
+++ b/microscope/wrappers/libBMC.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+## Copyright (C) 2017 David Pinto <david.pinto@bioch.ox.ac.uk>
+##
+## Microscope is free software: you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published by
+## the Free Software Foundation, either version 3 of the License, or
+## (at your option) any later version.
+##
+## Microscope is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with Microscope.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Boston Micromachines deformable mirrors SDK.
+"""
+
+import ctypes
+import sys
+
+from ctypes import c_char
+from ctypes import c_char_p
+from ctypes import c_double
+from ctypes import c_int
+from ctypes import c_uint
+from ctypes import c_uint32
+
+
+if sys.platform == "win32":
+  ## Not actually tested yet
+  SDK = ctypes.windll.BMC
+else:
+  SDK = ctypes.cdll.LoadLibrary("libBMC.so.3")
+
+
+## Definitions from BMCDefs.h
+MAX_PATH = 260
+SERIAL_NUMBER_LEN = 11
+MAX_DM_SIZE = 4096
+
+class DM_PRIV(ctypes.Structure):
+  pass
+
+class DM_DRIVER(ctypes.Structure):
+  _fields_ = [
+      ("channel_count", c_uint),
+      ("serial_number", c_char * (SERIAL_NUMBER_LEN+1)),
+      ("reserved", c_uint * 7)
+  ]
+
+class DM(ctypes.Structure):
+  _fields_ = [
+      ("Driver_Type", c_uint),
+      ("DevId", c_uint),
+      ("HVA_Type", c_uint),
+      ("use_fiber", c_uint),
+      ("use_CL", c_uint),
+      ("burst_mode", c_uint),
+      ("fiber_mode", c_uint),
+      ("ActCount", c_uint),
+      ("MaxVoltage", c_uint),
+      ("VoltageLimit", c_uint),
+      ("mapping", c_char * MAX_PATH),
+      ("inactive", c_uint * MAX_DM_SIZE),
+      ("profiles_path", c_char * MAX_PATH),
+      ("maps_path", c_char * MAX_PATH),
+      ("cals_path", c_char * MAX_PATH),
+      ("cal", c_char * MAX_PATH),
+      ("serial_number", c_char * (SERIAL_NUMBER_LEN+1)),
+      ("driver", DM_DRIVER),
+      ("priv", ctypes.POINTER(DM_PRIV)),
+  ]
+
+DMHANDLE = ctypes.POINTER(DM)
+
+RC = c_int # enum for error codes
+
+LOGLEVEL = c_int # enum for log-levels
+LOG_ALL = 0
+LOG_TRACE = LOG_ALL
+LOG_DEBUG = 1
+LOG_INFO = 2
+LOG_WARN = 3
+LOG_ERROR = 4
+LOG_FATAL = 5
+LOG_OFF = 6
+
+
+def make_prototype(name, argtypes, restype=RC):
+  func = getattr(SDK, name)
+  func.argtypes = argtypes
+  func.restype = restype
+  return func
+
+Open = make_prototype("BMCOpen", [DMHANDLE, c_char_p])
+
+SetArray = make_prototype("BMCSetArray", [DMHANDLE, ctypes.POINTER(c_double),
+                                          ctypes.POINTER(c_uint32)])
+
+GetArray = make_prototype("BMCGetArray", [DMHANDLE, ctypes.POINTER(c_double),
+                                          c_uint32])
+
+ClearArray = make_prototype("BMCClearArray", [DMHANDLE])
+
+Close = make_prototype("BMCClose", [DMHANDLE])
+
+ErrorString = make_prototype("BMCErrorString", [RC], c_char_p)
+
+ConfigureLog = make_prototype("BMCConfigureLog", [c_char_p, LOGLEVEL])
+
+VersionString = make_prototype("BMCVersionString", [], c_char_p)

--- a/microscope/wrappers/libasdk.py
+++ b/microscope/wrappers/libasdk.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+## Copyright (C) 2017 David Pinto <david.pinto@bioch.ox.ac.uk>
+##
+## Microscope is free software: you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published by
+## the Free Software Foundation, either version 3 of the License, or
+## (at your option) any later version.
+##
+## Microscope is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with Microscope.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Alpao deformable mirrors SDK
+"""
+
+import ctypes
+import sys
+
+from ctypes import c_char_p
+from ctypes import c_double
+from ctypes import c_int
+from ctypes import c_size_t
+from ctypes import c_uint32
+
+
+if sys.platform == "win32":
+  SDK = ctypes.windll.ASDK
+else:
+  ## Not actually tested yet
+  SDK = ctypes.cdll.LoadLibrary("libasdk.so")
+
+
+class DM(ctypes.Structure):
+  pass
+pDM = ctypes.POINTER(DM)
+
+## We have this "typedefs" to ease matching with alpao's headers.
+CStr = c_char_p
+Scalar = c_double
+Scalar_p = ctypes.POINTER(Scalar)
+UInt = c_uint32
+Size_T = c_size_t
+
+COMPL_STAT = c_int # enum for function completion status
+SUCCESS = 0
+FAILURE = -1
+
+
+def make_prototype(name, argtypes, restype=COMPL_STAT):
+  func = getattr(SDK, name)
+  func.argtypes = argtypes
+  func.restype = restype
+  return func
+
+Get = make_prototype("asdkGet", [pDM, CStr, Scalar_p])
+
+GetLastError = make_prototype("asdkGetLastError",
+                              [ctypes.POINTER(UInt), CStr, Size_T])
+
+Init = make_prototype("asdkInit", [CStr], pDM)
+
+Release = make_prototype("asdkRelease", [pDM])
+
+Reset = make_prototype("asdkReset", [pDM])
+
+Send = make_prototype("asdkSend", [pDM, Scalar_p])
+
+SendPattern = make_prototype("asdkSendPattern", [pDM, Scalar_p, UInt, UInt])
+
+Set = make_prototype("asdkSet", [pDM, CStr, Scalar])

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setuptools.setup(
     "microscope.cameras",
     "microscope.lasers",
     "microscope.testsuite",
+    "microscope.wrappers",
   ],
 
   install_requires = [


### PR DESCRIPTION
This creates a new subpackage named wrappers and adds two new modules that wrap libBMC (boston micromachines) and libasdk (alpao).

Some of the things I am unsure about:

* Maybe drop the `lib` part of the name? But makes it easier to point that this is the wrapper to a C lib if we ever wrap something else.

* Change the function names?  I am using the function name minus the library prefix BMC and asdk.  Keeping the function is nice because it maps nicely to the original documentation but also means we end with functions named `Set`, `Get`, and `Open`. If we follow the rule of using the same name, then one day we could clash with some reserved python word.

* functions to actually wrap.  At the moment we are only wrapping the ones I need on the mirror modules, but if we plan on providing this wrapper for end user, maybe we should wrap a few more. It is only a bit more of work. The alternative of only wrapping the ones we need would imply that we would remove functions later if we stop using them which would mean end-users can't rely on them, which would mean why would they use it in the first place?