### PR TITLE
Fix issue74

### DIFF
--- a/microscope/devices.py
+++ b/microscope/devices.py
@@ -1059,30 +1059,38 @@ class LaserDevice(Device):
 class FilterWheelBase(Device):
     __metaclass__ = abc.ABCMeta
 
-    def __init__(self, filters, *args, **kwargs):
+    def __init__(self, *args, filters=[], positions=0, **kwargs):
         super(FilterWheelBase, self).__init__(*args, **kwargs)
-        self._filters = {f[0]: f[1:] for f in filters}
+        if isinstance(filters, dict):
+            self._filters = filters
+        else:
+            self._filters = {i:f for (i, f) in enumerate(filters)}
         self._inv_filters = {val: key for key, val in self._filters.items()}
+        if not hasattr(self, '_positions') and positions != 0:
+            self._positions = positions
         # The position as an integer.
+        # Deprecated: clients should call get_position and set_position;
+        # still exposed as a setting until cockpit uses set_position.
         self.add_setting('position',
                          'int',
-                         self._get_position,
-                         self._set_position,
-                         (0, 5))
-        # The selected filter.
-        self.add_setting('filter',
-                         'enum',
-                         lambda: self._filters[self._get_position()],
-                         lambda val: self._set_position(self._inv_filters[val]),
-                         self._filters.values)
+                         self.get_position,
+                         self.set_position,
+                         (0, self.get_num_positions) )
+
+
+    def get_num_positions(self):
+        """Returns the number of wheel positions."""
+        return(max( self._positions, len(self._filters)))
 
     @abc.abstractmethod
-    def _get_position(self):
-        return self._position
+    def get_position(self):
+        """Return the wheel's current position"""
+        return 0
 
     @abc.abstractmethod
-    def _set_position(self, position):
-        self._position = position
+    def set_position(self, position):
+        """Set the wheel position."""
+        pass
 
     def get_filters(self):
-        return self._filters.items()
+        return [(k,v) for k,v in self._filters.items()]

--- a/microscope/testsuite/devices.py
+++ b/microscope/testsuite/devices.py
@@ -181,15 +181,16 @@ class TestCamera(devices.CameraDevice):
 
 
 class TestFilterWheel(FilterWheelBase):
-    def __init__(self, filters=[], *args, **kwargs):
-        super(TestFilterWheel, self).__init__(filters, *args, **kwargs)
+    def __init__(self, *args, **kwargs):
+        super(TestFilterWheel, self).__init__(*args, **kwargs)
         self._position = 0
 
-    def _get_position(self):
+    def get_position(self):
         return self._position
 
-    def _set_position(self, position):
+    def set_position(self, position):
         time.sleep(1)
+        self._logger.info("Setting position to %s" % position)
         self._position = position
 
     def initialize(self):

--- a/microscope/testsuite/test_devices.py
+++ b/microscope/testsuite/test_devices.py
@@ -442,14 +442,17 @@ class TestEmptyDummyFilterWheel(unittest.TestCase, FilterWheelTests):
 
 class TestOneFilterDummyFilterWheel(unittest.TestCase, FilterWheelTests):
     def setUp(self):
-        self.device = dummies.TestFilterWheel([(0, 'DAPI', '430')])
+        self.device = dummies.TestFilterWheel(filteres=[(0, 'DAPI', '430')])
 
 
 class TestMultiFilterDummyFilterWheel(unittest.TestCase, FilterWheelTests):
     def setUp(self):
-        self.device = dummies.TestFilterWheel([(0, 'DAPI', '430'),
-                                               (1, 'GFP', '580'),])
+        self.device = dummies.TestFilterWheel(filters=[(0, 'DAPI', '430'),
+                                                       (1, 'GFP', '580'),])
 
+class TestEmptySixPositionFilterWheel(unittest.TestCase, FilterWheelTests):
+    def setUp(self):
+        self.device = dummies.TestFilterWheel(positions=6)
 
 class TestDummyDeformableMirror(unittest.TestCase, DeformableMirrorTests):
     def setUp(self):


### PR DESCRIPTION
Fixed Thorlabs filter wheel and updated interface.
    
The wheel position and filter were exposed as settings, but this complicates things needlessly: clients should just call get_position, set_position and get_filters, directly. Nothing used the 'filters' setting, so I've removed it now. I've marked the 'position' setting as deprecated, as it is currently used by cockpit. Eventually, it should be removed.
    
The 'filters' argument is now an optional keyword for all filterwheels. It can be a list, or a dict mapping possition to filter, where each entry is either a description string, or a tuple of description and some value (e.g. wavelength, neutral density, ...). Alternatively, filterwheels may be created using a 'positions' keyword argument to specify the total number of positions the wheel offers. This will usually be hard-coded in the concrete implementations, as it is usually fixed for a given model of filter wheel.
    
Some filter wheels have manual controls. I considered having a polling thread to regularly query the wheel position and thereby catch manual position changes. However, filterwheels currently have no mechanism to notify the client of a change, so we leave it to the client to ensure they query the wheel position as needed, either before actions where the wheel's position is critical, or regularly, as required.