### PR TITLE
Defines behaviour for enum-type settings.

### DIFF
--- a/microscope/cameras/andorsdk3.py
+++ b/microscope/cameras/andorsdk3.py
@@ -345,8 +345,8 @@ class AndorSDK3(devices.FloatingDeviceMixin,
 
                 is_readonly_func = var.is_readonly
                 if type(var) is ATEnum:
-                    set_func = var.set_string
-                    get_func = var.get_string
+                    set_func = var.set_index
+                    get_func = var.get_index
                     vals_func = var.get_available_values
                 else:
                     set_func = var.set_value

--- a/microscope/devices.py
+++ b/microscope/devices.py
@@ -87,6 +87,10 @@ class Setting():
         A client needs some way of knowing a setting name and data type,
         retrieving the current value and, if settable, a way to retrieve
         allowable values, and set the value.
+
+        Setters and getters accept or return:
+            the setting value for int, float, bool and str;
+            the setting index into a list, dict or Enum type for enum.
         """
         self.name = name
         if dtype not in DTYPES:

--- a/microscope/testsuite/devices.py
+++ b/microscope/testsuite/devices.py
@@ -30,6 +30,15 @@ from microscope import devices
 from microscope.devices import keep_acquiring
 from microscope.devices import FilterWheelBase
 
+from enum import IntEnum
+
+class CamEnum(IntEnum):
+    A = 1
+    B = 2
+    C = 3
+    D = 4
+
+
 @Pyro4.behavior('single')
 class TestCamera(devices.CameraDevice):
     def __init__(self, *args, **kwargs):
@@ -61,6 +70,17 @@ class TestCamera(devices.CameraDevice):
                          lambda: self._gain,
                          self._set_gain,
                          lambda: (0, 8192))
+        # Enum-setting tests
+        self._listEnum = 0
+        self.add_setting('listEnum', 'enum',
+                         lambda: self._listEnum,
+                         lambda val: setattr(self, '_listEnum', val),
+                         ['A', 'B', 'C', 'D'])
+        self._intEnum = CamEnum.A
+        self.add_setting('intEnum', 'enum',
+                         lambda: self._intEnum,
+                         lambda val: setattr(self, '_intEnum', val),
+                         CamEnum)
         self._acquiring = False
         self._exposure_time = 0.1
         self._triggered = 0


### PR DESCRIPTION
 * Fixed the behaviour for ATEnums in andorsdk3
 * Added statement of behaviour to Setting docstring
 * Added tests for two types of enum settings to TestCamera

Fixes MicronOxford/cockpit#482