### PR TITLE
Use Binning & ROI structures throughout, and fix some cam issues.

### DIFF
--- a/doc/camera-template.py
+++ b/doc/camera-template.py
@@ -18,6 +18,7 @@
 """Test camera device. """
 from microscope import devices
 from microscope.devices import keep_acquiring
+from microscope.devices import ROI, Binning
 import Pyro4
 
 # Trigger mode to type.
@@ -69,19 +70,19 @@ class TemplateCamera(devices.CameraDevice):
 
     def _get_binning(self):
         """Return the current binning (horizontal, vertical)."""
-        return (1,1)
+        return Binning(1,1)
 
     @keep_acquiring
-    def _set_binning(self, h, v):
+    def _set_binning(self, binning):
         """Set binning to (h, v)."""
         return False
 
     def _get_roi(self):
         """Return the current ROI (left, top, width, height)."""
-        return (0, 0, 512, 512)
+        return ROI(0, 0, 512, 512)
 
     @keep_acquiring
-    def _set_roi(self, left, top, width, height):
+    def _set_roi(self, roi):
         """Set the ROI to (left, tip, width, height)."""
         return False
 

--- a/microscope/cameras/andorsdk3.py
+++ b/microscope/cameras/andorsdk3.py
@@ -30,6 +30,7 @@ import numpy as np
 
 from microscope import devices
 from microscope.devices import keep_acquiring
+from microscope.devices import ROI
 
 from .SDK3Cam import *
 
@@ -445,9 +446,9 @@ class AndorSDK3(devices.FloatingDeviceMixin,
         return tuple(int(t) for t in as_text)
 
     @keep_acquiring
-    def _set_binning(self, h, v):
+    def _set_binning(self, binning):
         modes = self._aoi_binning.get_available_values()
-        as_text = '%dx%d' % (h,v)
+        as_text = '%dx%d' % (binning.h, binning.v)
         if as_text in modes:
             self._aoi_binning.set_string(as_text)
             self._create_buffers()
@@ -456,26 +457,26 @@ class AndorSDK3(devices.FloatingDeviceMixin,
             return False
 
     def _get_roi(self):
-        return (self._aoi_left.get_value(),
-                self._aoi_top.get_value(),
-                self._aoi_width.get_value(),
-                self._aoi_height.get_value())
+        return ROI(self._aoi_left.get_value(),
+                   self._aoi_top.get_value(),
+                   self._aoi_width.get_value(),
+                   self._aoi_height.get_value())
 
     @keep_acquiring
-    def _set_roi(self, x, y, width, height):
+    def _set_roi(self, roi):
         current = self.get_roi()
         if self._acquiring:
             self.abort()
         try:
-            self._aoi_width.set_value(width)
-            self._aoi_height.set_value(height)
-            self._aoi_left.set_value(x)
-            self._aoi_top.set_value(y)
+            self._aoi_width.set_value(roi.width)
+            self._aoi_height.set_value(roi.height)
+            self._aoi_left.set_value(roi.left)
+            self._aoi_top.set_value(roi.top)
         except:
-            self._aoi_width.set_value(current[2])
-            self._aoi_height.set_value(current[3])
-            self._aoi_left.set_value(current[0])
-            self._aoi_top.set_value(current[1])
+            self._aoi_width.set_value(current.width)
+            self._aoi_height.set_value(current.height)
+            self._aoi_left.set_value(current.left)
+            self._aoi_top.set_value(current.top)
             return False
         return True
 

--- a/microscope/cameras/atmcd.py
+++ b/microscope/cameras/atmcd.py
@@ -1297,6 +1297,13 @@ class AndorAtmcd(devices.FloatingDeviceMixin,
                                           setter is None)
         # Set a conservative default temperature set-point.
         self.settings[name].set(-20)
+        # Fan control
+        name = 'Fan mode'
+        self.settings[name] = Setting(name, 'enum',
+                                      self._bind(GetFanMode),
+                                      self._bind(SetFanMode),
+                                      {0:'full', 1:'low', 2:'off'}
+                                      )
         # Cooler control
         name = 'Cooler Enabled'
         self.settings[name] = Setting(name, 'bool',

--- a/microscope/cameras/atmcd.py
+++ b/microscope/cameras/atmcd.py
@@ -1308,7 +1308,7 @@ class AndorAtmcd(devices.FloatingDeviceMixin,
         name = 'Binning'
         self.settings[name] = Setting(name, 'tuple',
                                       self.get_binning,
-                                      lambda hv: self.set_binning(*hv),
+                                      self.set_binning,
                                       None)
         # Roi
         name = 'Roi'
@@ -1511,9 +1511,9 @@ class AndorAtmcd(devices.FloatingDeviceMixin,
         return self._binning
 
     @keep_acquiring
-    def _set_binning(self, h=1, v=1):
+    def _set_binning(self, binning):
         """Set horizontal and vertical binning. Default to single pixel."""
-        self._binning = Binning(h, v)
+        self._binning = binning
         return True
 
     def _get_roi(self):
@@ -1521,19 +1521,15 @@ class AndorAtmcd(devices.FloatingDeviceMixin,
         return self._roi
 
     @keep_acquiring
-    def _set_roi(self, left=None, top=None, width=None, height=None):
+    def _set_roi(self, roi):
         """Set the ROI, defaulting to full sensor area."""
         with self:
             x, y = GetDetector()
-        if left is None:
-            left = 1
-        if top is None:
-            top = 1
-        if width is None:
-            width = x
-        if height is None:
-            height = y
+        left = roi.left or 1
+        top = roi.top or 1
+        width = roi.width or x
+        height = roi.height or y
         if any([left < 1, top < 1, left+width-1 > x, top+height-1 > y]):
             return False
-        self._roi = Roi(left, top, width, height)
+        self._roi = ROI(left, top, width, height)
         return True

--- a/microscope/cameras/atmcd.py
+++ b/microscope/cameras/atmcd.py
@@ -1129,7 +1129,7 @@ class ReadoutMode():
 from threading import Lock
 import functools
 from microscope import devices
-from microscope.devices import keep_acquiring, Setting, Binning, Roi
+from microscope.devices import keep_acquiring, Setting, Binning, ROI
 import time
 
 # A lock on the DLL used to ensure DLL calls act on the correct device.
@@ -1223,8 +1223,8 @@ class AndorAtmcd(devices.FloatingDeviceMixin,
             # Initialize the library and connect to camera.
             Initialize(b'')
             # Initialise ROI to full sensor area and binning to single-pixel.
-            self._set_roi()
-            self._set_binning()
+            self._set_roi(ROI(0,0,0,0))
+            self._set_binning(Binning(1,1))
             # Check info bits to see if initialization successful.
             info = GetCameraInformation(self._index)
             if not info & 1<<2:
@@ -1364,7 +1364,7 @@ class AndorAtmcd(devices.FloatingDeviceMixin,
         height = roi.height // binning.v
         try:
             with self:
-                data = GetOldestImage16(width * height).reshape(width, height)
+                data = GetOldestImage16(width * height).reshape(height, width)
         except AtmcdException as e:
             if e.status == DRV_NO_NEW_DATA:
                 return None
@@ -1478,7 +1478,7 @@ class AndorAtmcd(devices.FloatingDeviceMixin,
             # opposite edges from the chip. We set the horizontal flip
             # so that the returned image orientation is independent of
             # amplifier selection
-            SetImageFlip(mode.amp, 0)
+            SetImageFlip(not mode.amp, 0)
             SetHSSpeed(mode.amp, mode.hsindex)
 
     def _get_sensor_shape(self):

--- a/microscope/cameras/pvcam.py
+++ b/microscope/cameras/pvcam.py
@@ -606,9 +606,6 @@ class md_frame_roi_header(ctypes.Structure):
         ("_reserved", uns8*7),
     ]
 
-
-PL_MD_EXT_TAGS_MAX_SUPPORTED = 255
-
 class md_ext_item_info(ctypes.Structure):
     _fields_ = [
         ("tag", uns16),

--- a/microscope/cameras/pvcam.py
+++ b/microscope/cameras/pvcam.py
@@ -1271,8 +1271,8 @@ class PVCamera(devices.FloatingDeviceMixin, devices.CameraDevice):
             _cam_register_callback(self.handle, PL_CALLBACK_EOF, self._eof_callback)
             nbytes = _exp_setup_seq(self.handle, 1, 1, # cam, num epxosures, num regions
                                     self._region, TRIGGER_MODES[self._trigger].pv_mode, t_exp)
-            buffer_shape = (self.roi.width//self.binning.h,
-                            self.roi.height//self.binning.v)
+            buffer_shape = (self.roi.height//self.binning.v,
+                            self.roi.width // self.binning.h)
             self._buffer = np.require(np.zeros(buffer_shape, dtype='uint16'),
                                       requirements=['C_CONTIGUOUS','ALIGNED','OWNDATA'])
         else:
@@ -1289,8 +1289,9 @@ class PVCamera(devices.FloatingDeviceMixin, devices.CameraDevice):
             # Need to keep a reference to the callback.
             self._eof_callback = CALLBACK(cb)
             _cam_register_callback(self.handle, PL_CALLBACK_EOF, self._eof_callback)
-            buffer_shape = (self._circ_buffer_length, self.roi.width//self.binning.h,
-                            self.roi.height//self.binning.v)
+            buffer_shape = (self._circ_buffer_length,
+                            self.roi.height//self.binning.v,
+                            self.roi.width // self.binning.h)
             self._buffer = np.require(np.zeros(buffer_shape, dtype='uint16'),
                                           requirements=['C_CONTIGUOUS', 'ALIGNED', 'OWNDATA'])
             nbytes = _exp_setup_cont(self.handle, 1, self._region,

--- a/microscope/cameras/pvcam.py
+++ b/microscope/cameras/pvcam.py
@@ -1021,7 +1021,7 @@ class PVParam(object):
         if self.dtype == 'enum':
             # We may be passed a value, a description string, or a tuple of
             # (value, string).
-            values, descriptions = zip(*self.values.items())
+            values, descriptions = list(zip(*self.values.items()))
             if hasattr(new_value, '__iter__'):
                 desc = str(new_value[1])
             elif isinstance(new_value, str):

--- a/microscope/cameras/pvcam.py
+++ b/microscope/cameras/pvcam.py
@@ -1363,6 +1363,10 @@ class PVCamera(devices.FloatingDeviceMixin, devices.CameraDevice):
     @keep_acquiring
     def _set_roi(self, roi):
         """Set the ROI to (left, tip, width, height)."""
+        right = roi.left + roi.width
+        bottom = roi.top + roi.height
+        if (right, bottom) > self.shape:
+            raise Exception("ROI exceeds sensor area.")
         self.roi = roi
 
 

--- a/microscope/devices.py
+++ b/microscope/devices.py
@@ -688,14 +688,14 @@ class CameraDevice(DataDevice):
             transform = literal_eval(transform)
         self._client_transform = transform
         lr, ud, rot = (self._readout_transform[i] ^ transform[i] for i in range(3))
-        if self._readout_transform[2] and rot:
+        if self._readout_transform[2] and self._client_transform[2]:
             lr = not lr
             ud = not ud
         self._transform = (lr, ud, rot)
 
     def _set_readout_transform(self, new_transform):
         """Update readout transform and update resultant transform."""
-        self._readout_transform = new_transform
+        self._readout_transform = [bool(int(t)) for t in new_transform]
         self.set_transform(self._client_transform)
 
     @abc.abstractmethod

--- a/microscope/devices.py
+++ b/microscope/devices.py
@@ -96,8 +96,8 @@ class Setting():
         if dtype not in DTYPES:
             raise Exception('Unsupported dtype.')
         elif not (isinstance(values, DTYPES[dtype][1:]) or callable(values)):
-            raise Exception('Invalid values type for %s: expected function or %s' %
-                            (dtype, DTYPES[dtype][1:]))
+            raise Exception("Invalid values type for %s '%s': expected function or %s" %
+                            (dtype, name, DTYPES[dtype][1:]))
         self.dtype = DTYPES[dtype][0]
         self._get = get_func
         self._values = values
@@ -280,8 +280,8 @@ class Device(object):
         if dtype not in DTYPES:
             raise Exception('Unsupported dtype.')
         elif not (isinstance(values, DTYPES[dtype][1:]) or callable(values)):
-            raise Exception('Invalid values type for %s: expected function or %s' %
-                            (dtype, DTYPES[dtype][1:]))
+            raise Exception("Invalid values type for %s '%s': expected function or %s" %
+                            (dtype, name, DTYPES[dtype][1:]))
         else:
             self.settings[name] = Setting(name, dtype, get_func, set_func, values, readonly)
 
@@ -307,6 +307,7 @@ class Device(object):
             self.settings[name].set(value)
         except Exception as err:
             self._logger.error("in set_setting(%s):" % (name), exc_info=err)
+            raise
 
     def describe_setting(self, name):
         """Return ordered setting descriptions as a list of dicts."""

--- a/microscope/testsuite/devices.py
+++ b/microscope/testsuite/devices.py
@@ -109,10 +109,9 @@ class _ImageGenerator():
         return value * np.ones((h, w)).astype(d)
 
     def gradient(self, w, h, dark, light):
-        """A single gradient across the whole image that rotates about 0,0."""
-        th = next(self._theta)
+        """A single gradient across the whole image from top left to bottom right."""
         xx, yy = np.meshgrid(range(w), range(h))
-        return dark + light * (np.sin(th)*xx + np.cos(th)*yy) / (xx.max() + yy.max())
+        return dark + light * (xx + yy) / (xx.max() + yy.max())
 
     def noise(self, w, h, dark, light):
         """Random noise."""

--- a/microscope/testsuite/test_devices.py
+++ b/microscope/testsuite/test_devices.py
@@ -447,8 +447,10 @@ class TestImageGenerator(unittest.TestCase):
         for i, pattern in enumerate(patterns):
             with self.subTest(pattern):
                 generator.set_method(i)
-                pil_image = generator.get_image(width, height, 0, 255)
-                self.assertEqual(pil_image.size, (width, height))
+                array = generator.get_image(width, height, 0, 255)
+                # In matplotlib, an M-wide by N-tall image has M columns
+                # and N rows, so a shape of (N, M)
+                self.assertEqual(array.shape, (height, width))
 
 
 class TestEmptyDummyFilterWheel(unittest.TestCase, FilterWheelTests):


### PR DESCRIPTION
Using Binning and ROI named tuples on all cameras to remove ambiguity about specification and order of dimensions.

Image dimensions
 * Chosen image co-ordinates so that width and height refer to the width and height of an image plotted with matplotlib. 
 * Fixed up the ImageGenerator and its unit test accordingly.

pvcam
 * Fixed some parameter issues that broke settings in cockpit.
 * Added bounds check on ROI to prevent driver errors.
 * ROI works with PrimeBSI.
 * Can not set binning - the binning parameters are read only, although the spec sheet states that 2x2 should be available.

atmcd
 * Added fan control setting.
 * Fixed buffer shape for non-square ROI.
 * ROI and Binning work correctly with Ixon Ultra
 * Image was inverted, so fixed the readout-dependent, on-hardware image flip.
 * Note that ATMCD indexes pixels from 1, not 0. I haven't hidden this in microscope. If the user provides a bad ROI, the SDK corrects it for them.