### PR TITLE
added _on_shutdown and initialisefunction to clariy class

### DIFF
--- a/microscope/filterwheels/aurox.py
+++ b/microscope/filterwheels/aurox.py
@@ -262,3 +262,12 @@ class Clarity(microscope.devices.FilterWheelBase):
         while blocking and self.moving():
             pass
         return result
+
+    def _on_shutdown(self):
+        """Subclasses over-ride this with tasks to do on shutdown."""
+        pass
+
+    def initialize(self):
+        """Initialize the device."""
+        pass
+    


### PR DESCRIPTION
This fixes the startup errors in clarity device in issue #113 