### PR TITLE
Proposed changes to deviceserver log message format ... still too long?

### DIFF
--- a/microscope/deviceserver.py
+++ b/microscope/deviceserver.py
@@ -61,7 +61,7 @@ Pyro4.config.SERIALIZER = 'pickle'
 Pyro4.config.REQUIRE_EXPOSE = False
 
 
-def _create_log_formatter(name: str):
+def _create_log_formatter():
     """Create a logging.Formatter for the device server.
 
     Each device is served on its own process and each device has its
@@ -74,8 +74,9 @@ def _create_log_formatter(name: str):
         name (str): device name to be used on the log output.
 
     """
-    return logging.Formatter('%%(asctime)s:%s (%%(name)s):%%(levelname)s'
-                             ':PID %%(process)s: %%(message)s' % name)
+    return logging.Formatter('%(asctime)s:%(levelname)s:PID %(process)s:'
+                             '%(module)s:%(funcName)s:%(lineno)d:%(message)s')
+
 
 
 class Filter(logging.Filter):
@@ -170,7 +171,7 @@ class DeviceServer(multiprocessing.Process):
         # don't have UIDs available until after initialization, so
         # log to stderr until then.
         stderr_handler = StreamHandler(sys.stderr)
-        stderr_handler.setFormatter(_create_log_formatter(cls_name))
+        stderr_handler.setFormatter(_create_log_formatter())
         root_logger.addHandler(stderr_handler)
         root_logger.debug("Debugging messages on.")
 
@@ -248,7 +249,7 @@ def serve_devices(devices, exit_event=None):
     root_logger = logging.getLogger()
 
     log_handler = RotatingFileHandler("__MAIN__.log")
-    log_handler.setFormatter(_create_log_formatter('device-server'))
+    log_handler.setFormatter(_create_log_formatter())
     root_logger.addHandler(log_handler)
 
     root_logger.setLevel(logging.DEBUG)
@@ -429,7 +430,7 @@ def __console__():
         root_logger.setLevel(logging.INFO)
 
     stderr_handler = StreamHandler(sys.stderr)
-    stderr_handler.setFormatter(_create_log_formatter('device-server'))
+    stderr_handler.setFormatter(_create_log_formatter())
     root_logger.addHandler(stderr_handler)
 
     root_logger.addFilter(Filter())


### PR DESCRIPTION
The ('name') field is redundant now. I've replaced it with the module name, function name and line number that made the logging call.

Old messages:
```
2019-11-29 16:56:20,248:device-server (__main__):INFO:PID 25475: ... DeviceServer with PID 25478 restarted as PID 25482.
2019-11-29 16:56:20,250:Clarity (root):DEBUG:PID 25482: Debugging messages on.
```

New messages:
```
2019-11-29 16:57:26,835:INFO:PID 25525:deviceserver:keep_alive:345:... DeviceServer with PID 25530 restarted as PID 25535.
2019-11-29 16:57:26,837:DEBUG:PID 25535:deviceserver:run:176:Debugging messages on.
```