### PR TITLE
Ximea trig fix

### DIFF
--- a/microscope/cameras/ximea.py
+++ b/microscope/cameras/ximea.py
@@ -124,14 +124,14 @@ class XimeaCamera(devices.CameraDevice):
 
     def get_trigger_type(self):
         trig=self.handle.get_trigger_source()
-        if trig==XI_TRG_SOFTWARE:
+        if trig=='XI_TRG_SOFTWARE':
             return devices.TRIGGER_SOFT
-        elif trig==XI_TRG_EDGE_RISING:
+        elif trig=='XI_TRG_EDGE_RISING':
             return devices.TRIGGER_BEFORE
 
     def set_trigger_type(self, trigger):
         if (trigger == devices.TRIGGER_SOFT):
-            self.handle.set_triger_source(XI_TG_SOURCE['Xi_TRG_SOFTWARE'])
+            self.handle.set_triger_source(XI_TG_SOURCE['XI_TRG_SOFTWARE'])
         elif (trigger == devices.TRIGGER_BEFORE):
             self.handle.set_triger_source(XI_TG_SOURCE['Xi_TRG_EDGE_RISING'])
             #define digial input mode of trigger

--- a/microscope/cameras/ximea.py
+++ b/microscope/cameras/ximea.py
@@ -133,7 +133,7 @@ class XimeaCamera(devices.CameraDevice):
         if (trigger == devices.TRIGGER_SOFT):
             self.handle.set_triger_source(XI_TG_SOURCE['XI_TRG_SOFTWARE'])
         elif (trigger == devices.TRIGGER_BEFORE):
-            self.handle.set_triger_source(XI_TG_SOURCE['Xi_TRG_EDGE_RISING'])
+            self.handle.set_triger_source(XI_TG_SOURCE['XI_TRG_EDGE_RISING'])
             #define digial input mode of trigger
             self.handle.set_gpi_selector(1)
             self.handle.set_gpi_mode(XI_GPI_TRIGGER)


### PR DESCRIPTION
The triggers were no longer being set properly as the setting had been a enum and somewhere along the way the api changed it to a string. 