### PR TITLE
stop "conf"s all being the same dict

### DIFF
--- a/microscope/device_server.py
+++ b/microscope/device_server.py
@@ -81,7 +81,7 @@ def device(
     cls: typing.Callable,
     host: str,
     port: int,
-    conf: typing.Mapping[str, typing.Any] = {},
+    conf: typing.Mapping[str, typing.Any] = None,
     uid: typing.Optional[str] = None,
 ):
     """Define devices and where to serve them.
@@ -119,6 +119,8 @@ def device(
         ]
 
     """
+    if conf is None:
+        conf = {}
     if not callable(cls):
         raise TypeError("cls must be a callable")
     elif isinstance(cls, type):


### PR DESCRIPTION
When multiple devices are being created without a conf set, all `dev["conf"]`s are pointing to the same dictionary, meaning that they all have the same `_index`. This was making it impossible to load both AndorAtmcd cameras being loaded at once at B24 as it hit this:

```
    def initialize(self):
        """Initialize the library and hardware and create Setting objects."""
        _logger.info("Initializing ...")
        num_cams = GetAvailableCameras()
        if self._index >= num_cams:
            msg = "Requested camera %d, but only found %d cameras" % (
                self._index,
                num_cams,
            )
            raise microscope.InitialiseError(msg)
        self._handle = GetCameraHandle(self._index)
```
within the class `AndorAtmcd`